### PR TITLE
Possible workaround 

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,59 @@
+---
+output: github_document
+bibliography: inst/REFERENCES.bib
+link-citations: yes
+---
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "man/figures/README-",
+  out.width = "100%"
+)
+```
+
+# wrongabbreviation
+
+<!-- badges: start -->
+
+<!-- badges: end -->
+
+The goal of wrongabbreviation [@igraph] is to ...
+
+## Installation
+
+You can install the development version of wrongabbreviation from [GitHub](https://github.com/) with:
+
+``` r
+# install.packages("devtools")
+devtools::install_github("dieghernan/wrongabbreviation")
+```
+
+## Example
+
+This is a basic example which shows you how to solve a common problem:
+
+```{r example}
+library(wrongabbreviation)
+## basic example code
+```
+
+## Citation
+
+```{r echo=FALSE, results='asis'}
+print(citation("wrongabbreviation")[1], bibtex = FALSE)
+```
+
+A BibTeX entry for LaTeX users is
+
+```{r echo=FALSE, comment=''}
+toBibtex(citation("wrongabbreviation")[1])
+```
+
+## References
+
+::: {#refs}
+:::

--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+# wrongabbreviation
+
+<!-- badges: start -->
+<!-- badges: end -->
+
+The goal of wrongabbreviation ([Salmon and Test 2023](#ref-igraph)) is
+to …
+
+## Installation
+
+You can install the development version of wrongabbreviation from
+[GitHub](https://github.com/) with:
+
+``` r
+# install.packages("devtools")
+devtools::install_github("dieghernan/wrongabbreviation")
+```
+
+## Example
+
+This is a basic example which shows you how to solve a common problem:
+
+``` r
+library(wrongabbreviation)
+## basic example code
+```
+
+## Citation
+
+Salmon M, Test Sz (2023). *igraph: Network Analysis and Visualization in
+R*. <doi:10.5281/zenodo.7682609>
+<https://doi.org/10.5281/zenodo.7682609>, R package version 0.0.0.9000,
+<https://CRAN.R-project.org/package=igraph>.
+
+A BibTeX entry for LaTeX users is
+
+    @Manual{,
+      title = {{igraph}: Network Analysis and Visualization in R},
+      author = {Maëlle Salmon and {\relax Sz}abolcs Test},
+      year = {2023},
+      note = {R package version 0.0.0.9000},
+      doi = {10.5281/zenodo.7682609},
+      url = {https://CRAN.R-project.org/package=igraph},
+    }
+
+## References
+
+<div id="refs" class="references csl-bib-body hanging-indent">
+
+<div id="ref-igraph" class="csl-entry">
+
+Salmon, Maëlle, and Szabolcs Test. 2023. *<span
+class="nocase">igraph</span>: Network Analysis and Visualization in r*.
+<https://doi.org/10.5281/zenodo.7682609>.
+
+</div>
+
+</div>

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -4,15 +4,36 @@ year <- format(Sys.Date(), "%Y")
 
 authors <- meta$`Authors@R`
 authors <- utils:::.read_authors_at_R_field(authors)
-authors <- Filter(function(e) {!(is.null(e$given) && is.null(e$family)) && !is.na(match("aut", e$role))}, authors)
+authors <- Filter(function(e) {
+  !(is.null(e$given) && is.null(e$family)) && !is.na(match("aut", e$role))
+}, authors)
 authors <- format(authors, include = c("given", "family"))
-# TODO fix abbreviation of Szabolcs' name, should be Sz not S
-# could not get https://tex.stackexchange.com/q/26332/6302 to work no matter backslashes
 authors <- paste(paste(head(authors, -1L), collapse = ", "), tail(authors, 1L), sep = " and ")
-bibentry(bibtype = "Manual",
-         title = "{igraph}: Network Analysis and Visualization in R",
-         author = authors,
-         year = year,
-         note = note,
-         doi = "10.5281/zenodo.7682609",
-	 url = "https://CRAN.R-project.org/package=igraph")
+
+# Step 1: Get text citation and replace there the abb.
+entry_for_txt <- format(bibentry(
+  bibtype = "Manual",
+  title = "{igraph}: Network Analysis and Visualization in R",
+  author = authors,
+  year = year,
+  note = note,
+  doi = "10.5281/zenodo.7682609",
+  url = "https://CRAN.R-project.org/package=igraph"
+), style = "text")
+
+txt <- gsub("Test S", "Test Sz", entry_for_txt)
+
+aut_new <- sub("Szabolcs", "{\\\\relax Sz}abolcs", authors)
+
+
+bibentry(
+  bibtype = "Manual",
+  title = "{igraph}: Network Analysis and Visualization in R",
+  author = aut_new,
+  year = year,
+  note = note,
+  doi = "10.5281/zenodo.7682609",
+  url = "https://CRAN.R-project.org/package=igraph",
+  textVersion = txt
+)
+

--- a/inst/REFERENCES.bib
+++ b/inst/REFERENCES.bib
@@ -1,0 +1,8 @@
+@Manual{igraph,
+  title = {{igraph}: Network Analysis and Visualization in R},
+  author = {Maëlle Salmon and {\relax Sz}abolcs Test},
+  year = {2023},
+  note = {R package version 0.0.0.9000},
+  doi = {10.5281/zenodo.7682609},
+  url = {https://CRAN.R-project.org/package=igraph},
+}


### PR DESCRIPTION
Hi @maelle 

This problem is not as easy as I imagined. The Sz issue depends on the `print.bibentry()` method, that is from {base} so I have no way to access that.

But I was able to trick a little bit the function, basically:
1. I capture the output of an initial bibentry with `format.bibentry()`
2. I replace on the output "S" with "Sz" 
3. Add that to the final `bibentry` on `textVersion`.
4. Finally, I tried also to add the `{\relax Sz}` to the bibentry

With this, what we get is that:
- When converting the citation to bibtex we get the right bibtex entry
-  When printed as text instead of pasing the bibtex entry, it uses our `textVersion` text

This is not completely perfect, but it didn't give errors with `devtools::check()` and also works with {pkgdown}:ç
https://dieghernan.github.io/wrongabbreviation/authors.html#citation

However, see some warnings when trying to manipulate the `citation()` in specific styles. Hope this helps

``` r
# Is working!
citation("wrongabbreviation")
#> To cite package 'wrongabbreviation' in publications use:
#> 
#>   Salmon M, Test Sz (2023). _igraph: Network Analysis and Visualization
#>   in R_. doi:10.5281/zenodo.7682609
#>   <https://doi.org/10.5281/zenodo.7682609>, R package version
#>   0.0.0.9000, <https://CRAN.R-project.org/package=igraph>.
#> 
#> A BibTeX entry for LaTeX users is
#> 
#>   @Manual{,
#>     title = {{igraph}: Network Analysis and Visualization in R},
#>     author = {Maëlle Salmon and {\relax Sz}abolcs Test},
#>     year = {2023},
#>     note = {R package version 0.0.0.9000},
#>     doi = {10.5281/zenodo.7682609},
#>     url = {https://CRAN.R-project.org/package=igraph},
#>   }


ex <- citation("wrongabbreviation")

# As text only

print(ex, style = "citation", bibtex = FALSE)
#> To cite package 'wrongabbreviation' in publications use:
#> 
#>   Salmon M, Test Sz (2023). _igraph: Network Analysis and Visualization
#>   in R_. doi:10.5281/zenodo.7682609
#>   <https://doi.org/10.5281/zenodo.7682609>, R package version
#>   0.0.0.9000, <https://CRAN.R-project.org/package=igraph>.

print(ex, style = "bibtex")
#> @Manual{,
#>   title = {{igraph}: Network Analysis and Visualization in R},
#>   author = {Maëlle Salmon and {\relax Sz}abolcs Test},
#>   year = {2023},
#>   note = {R package version 0.0.0.9000},
#>   doi = {10.5281/zenodo.7682609},
#>   url = {https://CRAN.R-project.org/package=igraph},
#> }

# Some warnings here and not working... :(

print(ex, style = "text")
#> Warning in parseLatex(x): x:1: unexpected END_OF_INPUT '\relax'
#> Warning in parseLatex(x): x:1: unexpected '}'
#> Warning in parseLatex(x): x:1: unexpected END_OF_INPUT '\relax'
#> Warning in parseLatex(x): x:1: unexpected '}'
#> Warning in withCallingHandlers(.External2(C_parseRd, tcon, srcfile, "UTF-8", : <connection>:4: unexpected END_OF_INPUT '.
#> '
#> Salmon M, Test S (2023). _igraph: Network Analysis and Visualization in
#> R_. doi:10.5281/zenodo.7682609
#> <https://doi.org/10.5281/zenodo.7682609>, R package version 0.0.0.9000,
#> <https://CRAN.R-project.org/package=igraph>.
print(ex, style = "html")
#> Warning in parseLatex(x): x:1: unexpected END_OF_INPUT '\relax'
#> Warning in parseLatex(x): x:1: unexpected '}'
#> Warning in parseLatex(x): x:1: unexpected END_OF_INPUT '\relax'
#> Warning in parseLatex(x): x:1: unexpected '}'
#> Warning in withCallingHandlers(.External2(C_parseRd, tcon, srcfile, "UTF-8", : <connection>:5: unexpected END_OF_INPUT '
#> '
#> <p>Salmon M, Test S (2023).
#> <em>igraph: Network Analysis and Visualization in R</em>.
#> <a href="https://doi.org/10.5281/zenodo.7682609">doi:10.5281/zenodo.7682609</a>, R package version 0.0.0.9000, <a href="https://CRAN.R-project.org/package=igraph">https://CRAN.R-project.org/package=igraph</a>. 
#> </p>
print(ex, style = "latex")
#> Warning in parseLatex(x): x:1: unexpected END_OF_INPUT '\relax'
#> Warning in parseLatex(x): x:1: unexpected '}'
#> Warning in parseLatex(x): x:1: unexpected END_OF_INPUT '\relax'
#> Warning in parseLatex(x): x:1: unexpected '}'
#> Warning in withCallingHandlers(.External2(C_parseRd, tcon, srcfile, "UTF-8", : <connection>:4: unexpected END_OF_INPUT '.
#> '
#> Salmon M, Test S (2023).
#> \emph{igraph: Network Analysis and Visualization in R}.
#> \Rhref{https://doi.org/10.5281/zenodo.7682609}{doi:10.5281\slash{}zenodo.7682609}, R package version 0.0.0.9000, \url{https://CRAN.R-project.org/package=igraph}.
print(ex, style = "R")
#> bibentry(bibtype = "Manual",
#>          textVersion = "Salmon M, Test Sz (2023). _igraph: Network Analysis and Visualization in\nR_. doi:10.5281/zenodo.7682609\n<https://doi.org/10.5281/zenodo.7682609>, R package version 0.0.0.9000,\n<https://CRAN.R-project.org/package=igraph>.",
#>          title = "{igraph}: Network Analysis and Visualization in R",
#>          author = c(person(given = "Maëlle",
#>                            family = "Salmon"),
#>                     person(given = c("{\\relax", "Sz}abolcs"),
#>                            family = "Test")),
#>          year = "2023",
#>          note = "R package version 0.0.0.9000",
#>          doi = "10.5281/zenodo.7682609",
#>          url = "https://CRAN.R-project.org/package=igraph")
```

<sup>Created on 2023-05-05 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>





